### PR TITLE
Migrate to Sonatype / Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ builds.
 Gradle:
 
 ```groovy
-compile 'ch.threema.webrtc:webrtc-android:91.0.1'
+compile 'ch.threema:webrtc-android:91.0.1'
 ```
 
 Maven:
 
 ```xml
 <dependency>
-  <groupId>ch.threema.webrtc</groupId>
+  <groupId>ch.threema</groupId>
   <artifactId>webrtc-android</artifactId>
   <version>91.0.1</version>
   <type>pom</type>
@@ -152,31 +152,13 @@ Like v84.0.0, but with the following additional patch:
      8201 Jun 23 09:01 patches/fix-sctp-pointer-leak.patch
 
 
-## Hashes
+## Signatures
 
-These are the SHA256 hashes for the published releases of this project:
+Releases to Maven Central are signed with the following PGP key:
 
-- v91.0.1 ``
-- v91.0.0 `cbb3ed1e4d93dd294eccd7f84a80fdd5751061258c881c76455d9c0bf1be133f`
-- v84.2.0 `a66dcfa6b27f51d396b6a458ffca97ec463c820889e2e619a763976cacb0aa64`
-- v84.1.1 `23c96340d055b5bd27503f6ebad831f0222689c4cc8816aa343e8f3110566419`
-- v84.1.0 `d514bd6b770efe60c8de390c63aa893742376e32f67f692305b424e534d30036`
-- v84.0.0 `8a0b44347669ea46c61edb783e2f04195fb8a6a36d95751947b218f7275d45eb`
-- v83.1.1 `c5a14afe7a5edcade0bccb53c1308a1b0309422b6cca716822dc98fc76a0e779`
-- v83.1.0 `4b05eabe62470bf84adcf8b5a1eb8f99e71b0c3ecff29646626e491ebd22437d`
-- v83.0.0 `076b3ddde70690db31b42268b66a3c87f2be47aa11108c86a36baa2f44bc67bb`
-- v81.1.0 `b4315cad78f5ce6ff79bc1091cd44361fbe90c1d32edc5f25b426ddfa261bea8`
-- v81.0.0 `d46c81d0ecda1cc8fe74a89a905171fb0d0c7a95c632f1612a3aaa874ca0b0a6`
-- v80.0.0 `bb7469f49d94492b38e1df47389a45f3d9d1e419e181182ab246cde3130ce285`
-- v79.0.0 `6ec0f358ecd676ca53f433a4b7c1b6797fc406adfbdc6d4817d912656013966e`
-- v78.0.0 `2a54022e2d8d69ce33897fddb45cec74c87413eefeebc48f81eaf548b649d200`
-- v77.0.0 `24797af64d17fd195f20b264029b14ee5024b4b6fdee27bd5363bdee79a868af`
-- v76.0.0 `7164372eb184e50081ab3139edf4e66c3aaa8b017b44b8fd42ef8e9f372f85a5`
-- v75.0.0 `9bdf02510ab8b30506557425985584441ee712ea435db4c6cd8d11116edba5d9`
-- v74.0.0 `0e61dcde1e0242db69b7798a705126c638170deac06c4dc927beea2922be1768`
-- v73.0.0 `92a10a82cb18331e863ca910c333420678e6ec0022448f2e67354845c440e0dd`
-- v72.0.1 `f23e9c382457fee661d232a8efb22fc4cfb90436a98785b2991af412faeaa99f`
-- v72.0.0 `30da1a431dd2b97b3d8492dbdfeeaf43c30e2d177e3782c098ab9d0c54d895df`
+    pub   rsa4096 2016-09-06 [SC] [expires: 2026-09-04]
+          E7AD D991 4E26 0E8B 35DF  B506 65FD E935 573A CDA6
+    uid           Threema Signing Key <dev@threema.ch>
 
 
 ## Local testing

--- a/README.md
+++ b/README.md
@@ -9,17 +9,14 @@ This is a WebRTC build with Java bindings packaged for Android.
 
 ## Installing
 
-The package is available [on
-Bintray](https://bintray.com/threema/maven/webrtc-android/). It includes the
-WebRTC PeerConnection build for ARM and x86, both 32 and 64 bit builds.
-
-> :warning: **Note:** Version 91 will probably be the last version uploaded to Bintray.
-> Future versions will be uploaded to Maven Central only!
+This package is available on Maven Central (starting with version 91.0.1). It
+includes the WebRTC PeerConnection build for ARM and x86, both 32 and 64 bit
+builds.
 
 Gradle:
 
 ```groovy
-compile 'ch.threema.webrtc:webrtc-android:91.0.0'
+compile 'ch.threema.webrtc:webrtc-android:91.0.1'
 ```
 
 Maven:
@@ -28,7 +25,7 @@ Maven:
 <dependency>
   <groupId>ch.threema.webrtc</groupId>
   <artifactId>webrtc-android</artifactId>
-  <version>91.0.0</version>
+  <version>91.0.1</version>
   <type>pom</type>
 </dependency>
 ```
@@ -38,6 +35,7 @@ Maven:
 
 These are the target commits for the releases:
 
+- v91.0.1 [`3e0c60ba4ef28a9f26fe991e5eec3150402c7dd3`](https://chromium.googlesource.com/external/webrtc/+/3e0c60ba4ef28a9f26fe991e5eec3150402c7dd3)
 - v91.0.0 [`3e0c60ba4ef28a9f26fe991e5eec3150402c7dd3`](https://chromium.googlesource.com/external/webrtc/+/3e0c60ba4ef28a9f26fe991e5eec3150402c7dd3)
 - v84.2.0 [`963cc1ef1336b52ca27742beb28bfbc211ed54d0`](https://chromium.googlesource.com/external/webrtc/+/963cc1ef1336b52ca27742beb28bfbc211ed54d0)
 - v84.1.1 [`963cc1ef1336b52ca27742beb28bfbc211ed54d0`](https://chromium.googlesource.com/external/webrtc/+/963cc1ef1336b52ca27742beb28bfbc211ed54d0)
@@ -58,6 +56,11 @@ The builds are created using [webrtc-build-docker](https://github.com/threema-ch
 
 
 ## Patches / Build config
+
+**v91.0.1** (`WEBRTC_COMPILE_ARGS: symbol_level=1 enable_libaom=false`):
+
+Like v91.0.0, but packaging was upgraded to Gradle 6.8 and the maven-publish plugin.
+Starting with this release, the library will only be published to Maven Central.
 
 **v91.0.0** (`WEBRTC_COMPILE_ARGS: symbol_level=1 enable_libaom=false`):
 
@@ -153,6 +156,7 @@ Like v84.0.0, but with the following additional patch:
 
 These are the SHA256 hashes for the published releases of this project:
 
+- v91.0.1 ``
 - v91.0.0 `cbb3ed1e4d93dd294eccd7f84a80fdd5751061258c881c76455d9c0bf1be133f`
 - v84.2.0 `a66dcfa6b27f51d396b6a458ffca97ec463c820889e2e619a763976cacb0aa64`
 - v84.1.1 `23c96340d055b5bd27503f6ebad831f0222689c4cc8816aa343e8f3110566419`
@@ -177,15 +181,15 @@ These are the SHA256 hashes for the published releases of this project:
 
 ## Local testing
 
-Create a local release to `/tmp/maven/`:
+Create a local publication (usually at `$HOME/.m2/repository/`):
 
-    ./gradlew uploadArchives
+    ./gradlew publishToMavenLocal
 
 Include it in your project like this:
 
     repositories {
         ...
-        maven { url "/tmp/maven" }
+        mavenLocal()
     }
 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,9 @@ Set variables:
 
     export VERSION=X.Y.Z
     export GPG_KEY=E7ADD9914E260E8B35DFB50665FDE935573ACDA6
-    export BINTRAY_USER=...
-    export BINTRAY_KEY=...
+
+Ensure that `ossrhUsername` and `ossrhPassword` are defined in your
+`~/.gradle/gradle.properties` file.
 
 Update version numbers:
 
@@ -16,20 +17,20 @@ Build:
     rm -r build
     ./gradlew build
 
-Add hash to README.md:
-
-    sha256sum build/outputs/aar/webrtc-android-release.aar
-
 Add and commit:
 
     git commit -S${GPG_KEY} -m "Release v${VERSION}"
 
-Publish the library to Bintray:
+Publish the library to Sonatype OSS / Maven Central:
 
-    ./gradlew bintrayUpload
+    ./gradlew publish
+
+Afterwards, go to https://s01.oss.sonatype.org/#stagingRepositories and:
+
+- Close the repository
+- Release the repository
 
 Tag and push:
 
     git tag -s -u ${GPG_KEY} v${VERSION} -m "Version ${VERSION}"
     git push && git push --tags
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,25 @@
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 
 plugins {
-    id 'com.github.dcendents.android-maven' version '2.1'
-    id 'com.jfrog.bintray' version '1.8.4'
+    id 'maven-publish'
+    id 'signing'
 }
 
-def webrtc_version = '91'
-def app_version = '91.0.0'
+ext {
+    groupId = 'ch.threema'
+    webrtcVersion = '91'
+    libraryVersion = '91.0.0'
+}
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-group = 'ch.threema.webrtc'
-version = app_version
 
 // Android configuration
 android {
@@ -64,10 +60,7 @@ android {
 // In this section you declare where to find the dependencies of your project
 repositories {
     jcenter()
-    maven {
-        url 'https://maven.google.com/'
-        name 'Google'
-    }
+    google()
 }
 
 // In this section you declare the dependencies for your production and test code
@@ -76,6 +69,74 @@ dependencies {
     implementation files('libs/libwebrtc.jar')
     // Test dependencies
     testImplementation 'junit:junit:4.12'
+}
+
+// Note: Because the android components are created only during the
+// afterEvaluate phase, you must configure your publications using the
+// afterEvaluate() lifecycle method.
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                artifact androidSourcesJar
+                artifact androidJavadocsJar
+
+                groupId = project.ext.groupId
+                artifactId = project.name
+                version = project.ext.libraryVersion
+
+                pom {
+                    name = 'WebRTC for Android'
+                    description = "WebRTC m${project.ext.webrtcVersion} builds for Android, with some custom patches applied"
+                    url = 'https://github.com/threema-ch/webrtc-android'
+
+                    scm {
+                        url = 'https://github.com/threema-ch/webrtc-android'
+                    }
+
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'LICENSE-APACHE'
+                        }
+                        license {
+                            name = 'The MIT License'
+                            url = 'LICENSE-MIT'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'db'
+                            name = 'Danilo Bargen'
+                            email = 'danilo.bargen@threema.ch'
+                        }
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+                def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots'
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
+                    credentials {
+                        username ossrhUsername
+                        password ossrhPassword
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        useGpgCmd() // Use gpg-agent. For config options, see `gradle.properties`.
+        sign publishing.publications.release
+    }
 }
 
 task androidJavadocs(type: Javadoc) {
@@ -94,40 +155,4 @@ task androidSourcesJar(type: Jar) {
 artifacts {
     archives androidSourcesJar
     archives androidJavadocsJar
-}
-
-// Upload to Bintray
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'maven'
-        name = 'webrtc-android'
-        userOrg = 'threema'
-        desc = 'WebRTC Builds for Android'
-        websiteUrl = 'https://webrtc.org/'
-        vcsUrl = 'https://github.com/threema-ch/webrtc-android.git'
-        publicDownloadNumbers = true
-        licenses = ['MIT', 'Apache-2.0']
-        labels = ['webrtc', 'android']
-        version {
-            name = app_version
-            desc = "WebRTC M${webrtc_version}"
-            released = new Date()
-            vcsTag = "v${app_version}"
-        }
-    }
-}
-
-// Upload to local Maven repo for testing
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: uri('/media/veracrypt1/maven'))
-            pom.version = app_version
-            pom.artifactId = 'webrtc-android'
-            pom.packaging = 'aar'
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 ext {
     groupId = 'ch.threema'
     webrtcVersion = '91'
-    libraryVersion = '91.0.0'
+    libraryVersion = '91.0.1'
 }
 
 apply plugin: 'com.android.library'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,5 @@
 org.gradle.jvmargs=-Xmx2048M
+
+# GnuPG config for signing
+signing.gnupg.keyName=E7ADD9914E260E8B35DFB50665FDE935573ACDA6
+signing.gnupg.useLegacyGpg=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
Bintray is now sunset, so we need to switch.

This includes an update to Gradle 6.8 and a version bump to 91.0.1.